### PR TITLE
Making .done() fire "end" asynchronously

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -144,6 +144,7 @@ StreamQueue.prototype._pipeNextStream = function() {
 
 // Queue each stream given in argument
 StreamQueue.prototype.done = function() {
+  var _self = this;
   if(this._ending) {
     throw new Error('The queue is already ending.');
   }
@@ -152,7 +153,9 @@ StreamQueue.prototype.done = function() {
   }
   this._ending = true;
   if(!this._running) {
-    this.emit('end');
+    process.nextTick(function () {
+      _self.emit('end');
+    });
   }
   return this;
 }

--- a/tests/index.mocha.js
+++ b/tests/index.mocha.js
@@ -408,6 +408,14 @@ describe('StreamQueue', function() {
 
     });
 
+    it('passes through "end" events', function(done) {
+      var parent = new StreamQueue();
+      var child = new StreamQueue();
+      child.done();
+      parent.queue(child);
+      parent.on('end', done);
+    });
+
   });
 
   describe('in object mode', function() {


### PR DESCRIPTION
When you have code like the following, you get unexpected results.  I named this file `test.js`, which is referenced in the code.

``` javascript
var streamqueue = require('streamqueue'),
    fs = require('fs'),
    queue = streamqueue()
        .queue(fs.createReadStream('test.js'))
        //.queue(streamqueue())
        .queue(fs.createReadStream('test.js'))
        .done()
        .on('data', function (data) {
            console.log('data length:', data.length);
        })
        .on('end', function () {
            console.log('end found');
        });
```

When you run it as-is, you get the following output, which is correct.

> data.length: 427
> data.length: 427
> end found

When you uncomment the one line, you get this:

> data length: 425

I tracked it down to [here](https://github.com/nfroidure/StreamQueue/blob/master/src/index.js#L155).  At that point you emit 'end' immediately when done is called.  It appears that the readable stream package also had a similar issue, so they emit theirs asynchronously (see [this comment](https://github.com/isaacs/readable-stream/commit/93bc2dc5ed4384af40b74488bf0def478e7eacf9#diff-ba6a0df0f5212f5cba5ca5179e209a17R52) from a previous commit and [`process.nextTick`](https://github.com/isaacs/readable-stream/blob/master/lib/_stream_readable.js#L922).  The simplest fix that I see would be to just use process.nextTick.
